### PR TITLE
Option to force enable color output

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -37,7 +37,8 @@ func L() ILogger {
 	return l
 }
 
-/* InitLogger initialize desired logger
+/*
+	InitLogger initialize desired logger
 
 Use:
 InitLogger("<logger name>")
@@ -52,7 +53,6 @@ Default:
 
 e.g.
 InitLogger("none") -> will initialize the mock logger
-
 */
 func InitLogger(loggerName string) {
 
@@ -74,6 +74,10 @@ func InitDefaultLogger() {
 
 func DisableColor(flag bool) {
 	prettylogger.DisableColor(flag)
+}
+
+func EnableColor(flag bool) {
+	prettylogger.EnableColor(flag)
 }
 
 func ListLoggersNames() []string {

--- a/prettylogger/colors.go
+++ b/prettylogger/colors.go
@@ -36,3 +36,9 @@ func DisableColor(flag bool) {
 		color.NoColor = true
 	}
 }
+
+func EnableColor(flag bool) {
+	if flag {
+		color.NoColor = false
+	}
+}


### PR DESCRIPTION
This PR is towards [issue #560 of kubescape/kubescape](https://github.com/kubescape/kubescape/issues/560). It introduces a function to force enable color output for ANSI-enabled non-tty environments (like Github Actions).