### PR TITLE
Sanitize invalid UTF-8 byte sequences from strings

### DIFF
--- a/helpers/datastructures.go
+++ b/helpers/datastructures.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const InvalidUtf8ReplacementString = "\uFFFD"
+
 type StringObj struct {
 	key   string
 	value string
@@ -25,9 +27,11 @@ type InterfaceObj struct {
 	value interface{}
 }
 
-func Error(e error) *ErrorObj                         { return &ErrorObj{key: "error", value: e} }
-func Int(k string, v int) *IntObj                     { return &IntObj{key: k, value: v} }
-func String(k, v string) *StringObj                   { return &StringObj{key: k, value: strings.ToValidUTF8(v, "")} }
+func Error(e error) *ErrorObj     { return &ErrorObj{key: "error", value: e} }
+func Int(k string, v int) *IntObj { return &IntObj{key: k, value: v} }
+func String(k, v string) *StringObj {
+	return &StringObj{key: k, value: strings.ToValidUTF8(v, InvalidUtf8ReplacementString)}
+}
 func Interface(k string, v interface{}) *InterfaceObj { return &InterfaceObj{key: k, value: v} }
 func Time() *StringObj {
 	return &StringObj{key: "time", value: time.Now().Format("2006-01-02 15:04:05")}

--- a/helpers/datastructures.go
+++ b/helpers/datastructures.go
@@ -1,6 +1,9 @@
 package helpers
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type StringObj struct {
 	key   string
@@ -24,7 +27,7 @@ type InterfaceObj struct {
 
 func Error(e error) *ErrorObj                         { return &ErrorObj{key: "error", value: e} }
 func Int(k string, v int) *IntObj                     { return &IntObj{key: k, value: v} }
-func String(k, v string) *StringObj                   { return &StringObj{key: k, value: v} }
+func String(k, v string) *StringObj                   { return &StringObj{key: k, value: strings.ToValidUTF8(v, "")} }
 func Interface(k string, v interface{}) *InterfaceObj { return &InterfaceObj{key: k, value: v} }
 func Time() *StringObj {
 	return &StringObj{key: "time", value: time.Now().Format("2006-01-02 15:04:05")}

--- a/zaplogger/loggerwithctx.go
+++ b/zaplogger/loggerwithctx.go
@@ -3,6 +3,7 @@ package zaplogger
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/kubescape/go-logger/helpers"
 
@@ -32,25 +33,25 @@ func (zl *ZapLoggerWithCtx) SetLevel(level string) error {
 	return err
 }
 func (zl *ZapLoggerWithCtx) Fatal(msg string, details ...helpers.IDetails) {
-	zl.zapL.Fatal(msg, detailsToZapFields(details)...)
+	zl.zapL.Fatal(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Error(msg string, details ...helpers.IDetails) {
-	zl.zapL.Error(msg, detailsToZapFields(details)...)
+	zl.zapL.Error(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Warning(msg string, details ...helpers.IDetails) {
-	zl.zapL.Warn(msg, detailsToZapFields(details)...)
+	zl.zapL.Warn(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Success(msg string, details ...helpers.IDetails) {
-	zl.zapL.Info(msg, detailsToZapFields(details)...)
+	zl.zapL.Info(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Info(msg string, details ...helpers.IDetails) {
-	zl.zapL.Info(msg, detailsToZapFields(details)...)
+	zl.zapL.Info(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Debug(msg string, details ...helpers.IDetails) {
-	zl.zapL.Debug(msg, detailsToZapFields(details)...)
+	zl.zapL.Debug(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
 }

--- a/zaplogger/loggerwithctx.go
+++ b/zaplogger/loggerwithctx.go
@@ -33,25 +33,25 @@ func (zl *ZapLoggerWithCtx) SetLevel(level string) error {
 	return err
 }
 func (zl *ZapLoggerWithCtx) Fatal(msg string, details ...helpers.IDetails) {
-	zl.zapL.Fatal(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Fatal(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Error(msg string, details ...helpers.IDetails) {
-	zl.zapL.Error(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Error(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Warning(msg string, details ...helpers.IDetails) {
-	zl.zapL.Warn(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Warn(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Success(msg string, details ...helpers.IDetails) {
-	zl.zapL.Info(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Info(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Info(msg string, details ...helpers.IDetails) {
-	zl.zapL.Info(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Info(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }
 
 func (zl *ZapLoggerWithCtx) Debug(msg string, details ...helpers.IDetails) {
-	zl.zapL.Debug(strings.ToValidUTF8(msg, ""), detailsToZapFields(details)...)
+	zl.zapL.Debug(strings.ToValidUTF8(msg, helpers.InvalidUtf8ReplacementString), detailsToZapFields(details)...)
 }


### PR DESCRIPTION
Due to the error below, I have added string sanitizing logic to remove invalid UTF-8 chars; When sending logs to an otel collector (gRPC) we got this:
 
```
{"level":"error","ts":"2023-03-09T16:32:57Z","msg":"previous logs of a crashed pod container:\n 2023-03-09T16:32:24.332509170Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:24Z\",\"msg\":\"Starting swagger UI. baseURI: /openapi/v2/, docsEP: docs, rapidocEP: rapi, swaggerui: swaggerui\"}\n2023-03-09T16:32:24.332927129Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:24Z\",\"msg\":\"Started Kubescape server\",\"port\":\"8080\",\"version\":\"v2.2.4\"}\n2023-03-09T16:32:35.416611426Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:35Z\",\"msg\":\"requesting status\",\"scanID\":\"a3950eab-afba-4285-983e-2df435d2d27e\",\"api\":\"v1/status\"}\n","containerName":"kubescape","restartCount":1,"state":"\n\ufffd\u0001\n\u0010CrashLoopBackOff\u0012\ufffd\u0001back-off 10s restarting failed container=kubescape pod=kubescape-6d474c8576-2ps8v_kubescape(1512972e-4dbc-4d33-8d47-5ea965265fb0)","lastState":"\u001ap\u0008\u0000\u0010\u0000\u001a\tCompleted\"\u0000*\u0008\u0008\ufffd\ufffd\ufffd\ufffd\u0006\u0010\u00002\u0008\u0008\ufffd\ufffd\ufffd\ufffd\u0006\u0010\u0000:Idocker://b68dd5925835958e4037c1e500105dabb9a8ca98ac14bafdb87c809692ca15fd"}
{"level":"error","ts":"2023-03-09T16:32:57Z","msg":"logs of a crashed pod container:\n 2023-03-09T16:32:24.332509170Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:24Z\",\"msg\":\"Starting swagger UI. baseURI: /openapi/v2/, docsEP: docs, rapidocEP: rapi, swaggerui: swaggerui\"}\n2023-03-09T16:32:24.332927129Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:24Z\",\"msg\":\"Started Kubescape server\",\"port\":\"8080\",\"version\":\"v2.2.4\"}\n2023-03-09T16:32:35.416611426Z {\"level\":\"info\",\"ts\":\"2023-03-09T16:32:35Z\",\"msg\":\"requesting status\",\"scanID\":\"a3950eab-afba-4285-983e-2df435d2d27e\",\"api\":\"v1/status\"}\n","containerName":"kubescape","restartCount":1,"state":"\n\ufffd\u0001\n\u0010CrashLoopBackOff\u0012\ufffd\u0001back-off 10s restarting failed container=kubescape pod=kubescape-6d474c8576-2ps8v_kubescape(1512972e-4dbc-4d33-8d47-5ea965265fb0)","lastState":"\u001ap\u0008\u0000\u0010\u0000\u001a\tCompleted\"\u0000*\u0008\u0008\ufffd\ufffd\ufffd\ufffd\u0006\u0010\u00002\u0008\u0008\ufffd\ufffd\ufffd\ufffd\u0006\u0010\u0000:Idocker://b68dd5925835958e4037c1e500105dabb9a8ca98ac14bafdb87c809692ca15fd"}
2023/03/09 16:32:58 rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8
```


Once this PR is merged, will bump the version in our in-cluster components.
