### PR TITLE
add space to info icon

### DIFF
--- a/iconlogger/logger.go
+++ b/iconlogger/logger.go
@@ -106,7 +106,7 @@ func getSymbol(level string) string {
 	case "debug":
 		return "🐞  "
 	default:
-		return "ℹ️ "
+		return "ℹ️   "
 	}
 }
 

--- a/iconlogger/logger_test.go
+++ b/iconlogger/logger_test.go
@@ -117,7 +117,7 @@ func TestGetSymbol(t *testing.T) {
 		{"Fatal", "fatal", "❌  "},
 		{"Error", "error", "❌  "},
 		{"Debug", "debug", "🐞  "},
-		{"Default", "info", "ℹ️ "},
+		{"Default", "info", "ℹ️   "},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds spaces to the information icon, so that the indentation will be the same as the other icons (please note that this one needs one more).

Previous behaviour:
![image](https://github.com/kubescape/go-logger/assets/84905812/0b233edb-20b8-4d63-adc6-f9694f1584cf)


Current behavior:
![image](https://github.com/kubescape/go-logger/assets/84905812/ec3692e8-e6ea-4dc7-8e10-99732f8ca0af)
