### PR TITLE
Fix spacing

### DIFF
--- a/iconlogger/logger.go
+++ b/iconlogger/logger.go
@@ -98,15 +98,15 @@ func detailsToString(details []helpers.IDetails) string {
 func getSymbol(level string) string {
 	switch level {
 	case "warning":
-		return " ❗ "
+		return " ⚠️   "
 	case "success":
-		return "✅  "
+		return " ✅  "
 	case "fatal", "error":
-		return "❌  "
+		return " ❌  "
 	case "debug":
-		return "🐞  "
+		return " 🐞  "
 	default:
-		return "ℹ️   "
+		return " ℹ️   "
 	}
 }
 

--- a/iconlogger/logger_test.go
+++ b/iconlogger/logger_test.go
@@ -112,12 +112,12 @@ func TestGetSymbol(t *testing.T) {
 		level  string
 		expect string
 	}{
-		{"Warning", "warning", " ❗ "},
-		{"Success", "success", "✅  "},
-		{"Fatal", "fatal", "❌  "},
-		{"Error", "error", "❌  "},
-		{"Debug", "debug", "🐞  "},
-		{"Default", "info", "ℹ️   "},
+		{"Warning", "warning", " ⚠️   "},
+		{"Success", "success", " ✅  "},
+		{"Fatal", "fatal", " ❌  "},
+		{"Error", "error", " ❌  "},
+		{"Debug", "debug", " 🐞  "},
+		{"Default", "info", " ℹ️   "},
 	}
 
 	for _, tt := range tests {

--- a/iconlogger/spinner.go
+++ b/iconlogger/spinner.go
@@ -16,7 +16,8 @@ func (il *IconLogger) StartSpinner(w *os.File, message string) {
 		return
 	}
 	if isSupported() {
-		il.spinner = spinnerpkg.New(spinnerpkg.CharSets[14], 100*time.Millisecond, spinnerpkg.WithWriterFile(w)) // Build our new spinner
+		il.spinner = spinnerpkg.New(spinnerpkg.CharSets[70], 100*time.Millisecond, spinnerpkg.WithWriterFile(w)) // Build our new spinner
+		il.spinner.Prefix = " "
 		il.spinner.Suffix = " " + message
 		il.spinner.Start()
 	}


### PR DESCRIPTION
Update the `iconlogger` to align log entries and the spinner.  Changes the spinner to use an emoji animation, and updates the warning icon to ⚠️, to allow alignment in fixed width.

_Before:_

https://github.com/kubescape/go-logger/assets/132510/d0052802-8848-49a4-8607-bdccbd1d9429

_After:_

https://github.com/kubescape/go-logger/assets/132510/e0bf42cc-8eed-40c6-9d10-7f8a13aeb603

