### PR TITLE
use sync.Once to initialize the internal logger

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -65,9 +65,6 @@ Default:
 If the logger name is empty, will try to get the logger name from the environment variable KS_LOGGER_NAME.
 If the logger level environment variable is set, will set the logger level to the value of the environment variable.
 
-InitLogger is not safe for concurrent use. It should be called once during
-program startup, before any concurrent access to L().
-
 e.g.
 InitLogger("none") -> will initialize the mock logger
 */

--- a/methods.go
+++ b/methods.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/go-logger/iconlogger"
@@ -23,14 +25,25 @@ const (
 	EnvLoggerName = "KS_LOGGER_NAME"
 )
 
-var l helpers.ILogger
+var (
+	// loggerPtr stores *helpers.ILogger; accessed atomically for lock-free reads.
+	loggerPtr atomic.Pointer[helpers.ILogger]
+	// initMu serializes initialization in InitLogger and the lazy path of L().
+	initMu sync.Mutex
+)
 
-// Return initialized logger. If logger not initialized, will call InitializeLogger() with the default value
+// L returns the initialized logger. If no logger has been set, it lazily initializes the default.
 func L() helpers.ILogger {
-	if l == nil {
-		InitDefaultLogger()
+	if p := loggerPtr.Load(); p != nil {
+		return *p
 	}
-	return l
+	initMu.Lock()
+	defer initMu.Unlock()
+	if p := loggerPtr.Load(); p != nil {
+		return *p
+	}
+	initLoggerInternal("")
+	return *loggerPtr.Load()
 }
 
 /*
@@ -52,37 +65,48 @@ Default:
 If the logger name is empty, will try to get the logger name from the environment variable KS_LOGGER_NAME.
 If the logger level environment variable is set, will set the logger level to the value of the environment variable.
 
+InitLogger is not safe for concurrent use. It should be called once during
+program startup, before any concurrent access to L().
+
 e.g.
 InitLogger("none") -> will initialize the mock logger
 */
 func InitLogger(loggerName string) {
+	initMu.Lock()
+	defer initMu.Unlock()
+	initLoggerInternal(loggerName)
+}
 
+func initLoggerInternal(loggerName string) {
 	if loggerName == "" {
-		// get logger name from environment variable
 		loggerName = os.Getenv(EnvLoggerName)
 	}
 
+	var newLogger helpers.ILogger
 	switch strings.ToLower(loggerName) {
 	case structuredlogger.LoggerName:
-		l = structuredlogger.NewStructuredLogger()
+		newLogger = structuredlogger.NewStructuredLogger()
 	case zaplogger.LoggerName:
-		l = zaplogger.NewZapLogger()
+		newLogger = zaplogger.NewZapLogger()
 	case prettylogger.LoggerName, "colorful":
-		l = prettylogger.NewPrettyLogger()
+		newLogger = prettylogger.NewPrettyLogger()
 	case iconlogger.LoggerName, "emoji":
-		l = iconlogger.NewIconLogger()
+		newLogger = iconlogger.NewIconLogger()
 	case nonelogger.LoggerName, "mock", "empty", "ignore":
-		l = nonelogger.NewNoneLogger()
+		newLogger = nonelogger.NewNoneLogger()
 	default:
-		l = prettylogger.NewPrettyLogger()
+		newLogger = prettylogger.NewPrettyLogger()
 	}
 
-	// set logger level from environment variable, if empty, will use the default value as set by the package
 	if lev := os.Getenv(EnvLoggerLevel); lev != "" {
-		if err := l.SetLevel(lev); err != nil {
-			l.Warning("failed to set logger level", helpers.String("environment", EnvLoggerLevel), helpers.Error(err))
+		if err := newLogger.SetLevel(lev); err != nil {
+			newLogger.Warning("failed to set logger level", helpers.String("environment", EnvLoggerLevel), helpers.Error(err))
 		}
 	}
+
+	// Caller must hold initMu.
+	iface := helpers.ILogger(newLogger)
+	loggerPtr.Store(&iface)
 }
 
 func InitDefaultLogger() {

--- a/methods_test.go
+++ b/methods_test.go
@@ -2,13 +2,20 @@ package logger
 
 import (
 	"os"
+	"sync"
 	"testing"
 
+	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/go-logger/nonelogger"
 	"github.com/kubescape/go-logger/prettylogger"
 	"github.com/kubescape/go-logger/structuredlogger"
 	"github.com/kubescape/go-logger/zaplogger"
 )
+
+// resetLogger clears the global logger so the next L() or InitLogger call reinitializes it.
+func resetLogger() {
+	loggerPtr.Store(nil)
+}
 
 func TestInitLogger(t *testing.T) {
 	type args struct {
@@ -156,17 +163,50 @@ func TestInitLogger(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resetLogger()
+
 			os.Setenv(EnvLoggerName, tt.envs.loggerName)
 			os.Setenv(EnvLoggerLevel, tt.envs.loggerLevel)
 
 			InitLogger(tt.args.loggerName)
 
-			if l.GetLevel() != tt.want.loggerLevel {
-				t.Errorf("GetLevel() = %v, want %v", l.GetLevel(), tt.want.loggerLevel)
+			logger := L()
+			if logger.GetLevel() != tt.want.loggerLevel {
+				t.Errorf("GetLevel() = %v, want %v", logger.GetLevel(), tt.want.loggerLevel)
 			}
-			if l.LoggerName() != tt.want.loggerName {
-				t.Errorf("LoggerName() = %v, want %v", l.LoggerName(), tt.want.loggerName)
+			if logger.LoggerName() != tt.want.loggerName {
+				t.Errorf("LoggerName() = %v, want %v", logger.LoggerName(), tt.want.loggerName)
 			}
 		})
+	}
+}
+
+func TestL_ConcurrentAccess(t *testing.T) {
+	resetLogger()
+
+	var wg sync.WaitGroup
+
+	// Half the goroutines call InitLogger, half call L().
+	// This exercises the InitLogger + L() interleaving that
+	// previously caused a deadlock due to lock ordering inversion.
+	const n = 100
+	loggers := make([]helpers.ILogger, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if idx%2 == 0 {
+				InitLogger("pretty")
+			}
+			loggers[idx] = L()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, logger := range loggers {
+		if logger == nil {
+			t.Errorf("goroutine %d: L() returned nil", i)
+		}
 	}
 }

--- a/zaplogger/logger.go
+++ b/zaplogger/logger.go
@@ -29,6 +29,7 @@ func NewZapLogger() *ZapLogger {
 	cfg.DisableStacktrace = true
 	cfg.Encoding = "json"
 	cfg.EncoderConfig = ec
+	cfg.Sampling = nil
 
 	zapLogger, err := cfg.Build()
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safe, one-time logger initialization to prevent races during concurrent access.
  * Disabled sampling in the logging system so all log messages are captured.

* **Tests**
  * Added concurrency tests to ensure a single logger instance is returned under concurrent access and reset test state between runs.

* **Documentation**
  * Clarified logger initialization guidance: initialize before concurrent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->