### PR TITLE
fix(otelsetup): change auth headers to X-API-KEY and X-API-ACCOUNT

### DIFF
--- a/otelsetup/otelsetup_test.go
+++ b/otelsetup/otelsetup_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestBuildAuthHeaders_WithCredentials(t *testing.T) {
 	h := buildAuthHeaders("my-key", "my-guid")
-	assert.Equal(t, "my-key", h["X-API-Key"], "X-API-Key must be set when accessKey is non-empty")
-	assert.Equal(t, "my-guid", h["X-Customer-GUID"], "X-Customer-GUID must be set when accessKey is non-empty")
+	assert.Equal(t, "my-key", h["X-API-KEY"], "X-API-KEY must be set when accessKey is non-empty")
+	assert.Equal(t, "my-guid", h["X-API-ACCOUNT"], "X-API-ACCOUNT must be set when accessKey is non-empty")
 }
 
 func TestBuildAuthHeaders_NoCredentials_ReturnsNil(t *testing.T) {

--- a/otelsetup/setup.go
+++ b/otelsetup/setup.go
@@ -3,7 +3,7 @@
 // exporter gating, credential header injection, TLS/plaintext detection, and
 // the in-memory ring-buffer log processor used for retroactive log export.
 //
-// Auth header policy: X-API-Key and X-Customer-GUID are injected whenever
+// Auth header policy: X-API-KEY and X-API-ACCOUNT are injected whenever
 // cfg.AccessKey is non-empty, regardless of the endpoint hostname. This is the
 // same credential-presence gate used by the SBOM scan-failure reporter and
 // avoids fragile hostname matching that breaks on domain changes or
@@ -58,7 +58,7 @@ type ProviderConfig struct {
 // MeterProvider. It returns a combined shutdown func that flushes batches with
 // a 5s timeout. When OTEL_EXPORTER_OTLP_ENDPOINT is unset, providers fall back
 // to no-op (no panics, no log noise). When cfg.AccessKey is non-empty,
-// X-API-Key and X-Customer-GUID headers are attached to every outbound RPC.
+// X-API-KEY and X-API-ACCOUNT headers are attached to every outbound RPC.
 func InitProviders(ctx context.Context, cfg ProviderConfig) (shutdown func(context.Context) error, err error) {
 	applyLegacyEnvAliases()
 
@@ -254,8 +254,8 @@ func buildAuthHeaders(accessKey, accountID string) map[string]string {
 		return nil
 	}
 	return map[string]string{
-		"X-API-Key":       accessKey,
-		"X-Customer-GUID": accountID,
+		"X-API-KEY":     accessKey,
+		"X-API-ACCOUNT": accountID,
 	}
 }
 


### PR DESCRIPTION
This PR updates the OTEL setup in go-logger to use the headers X-API-KEY and X-API-ACCOUNT instead of X-API-Key and X-Customer-GUID as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP authentication headers used in OTLP data transmission to align with current API specifications and ensure proper endpoint communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/go-logger/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->